### PR TITLE
Do not extend tl_settings

### DIFF
--- a/dca/tl_settings.php
+++ b/dca/tl_settings.php
@@ -21,7 +21,7 @@ $GLOBALS['TL_DCA']['tl_settings']['fields']['disabledTagObjects'] = array
 	'eval'                    => array('multiple'=>true)
 );
 
-class tl_settings_tags extends tl_settings
+class tl_settings_tags
 {
 	/**
 	 * Return available tag tables


### PR DESCRIPTION
Fixes #3 

Since `tl_settings_tags` does not actually use any functionality of `tl_settings`, extending `tl_settings` is not necessary.